### PR TITLE
Fixes for non-continuous calibration

### DIFF
--- a/src/calibrator/monitor.rs
+++ b/src/calibrator/monitor.rs
@@ -64,7 +64,7 @@ impl Calibrator for Monitor {
                 UnitQuaternion::from_quaternion(Quaternion::from(pose.orientation)).euler_angles();
             let pos = format!(
                 "X: {:.2}, Y: {:.2}, Z: {:.2}",
-                stage.position.x, stage.position.y, stage.position.z
+                pose.position.x, pose.position.y, pose.position.z
             );
             let space = " ".repeat(30 - pos.len().min(35));
             println!(" │     {pos} {space} Yaw: {yaw:.2}, Pitch: {pitch:.2}, Roll: {roll:.2}");

--- a/src/calibrator/sampled.rs
+++ b/src/calibrator/sampled.rs
@@ -299,7 +299,8 @@ impl Calibrator for SampledMethod {
         log::info!("Calibration done. Offset: {}", offset);
 
         let dst_root = TransformD::from(dst_origin.get_offset()?);
-        dst_origin.set_offset((offset * dst_root).into())?;
+        let full_offset = offset * dst_root;
+        dst_origin.set_offset(full_offset.into())?;
 
         if self.maintain {
             let offset = self.avg_b_to_a_offset(&offset);
@@ -325,11 +326,12 @@ impl Calibrator for SampledMethod {
             ))))
         } else {
             let src_origin = data.get_device_origin(self.src_dev)?;
+            let src_root = TransformD::from(src_origin.get_offset()?);
             match data.save_calibration(
                 &self.profile,
                 src_origin.id as _,
                 dst_origin.id as _,
-                dst_root,
+                full_offset * src_root.inverse(),
                 OffsetType::TrackingOrigin,
             ) {
                 Ok(_) => log::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,13 +354,19 @@ fn xr_loop(args: Args, monado: mnd::Monado, mut status: MultiProgress) -> anyhow
 
                                 match last.offset_type {
                                     OffsetType::TrackingOrigin => {
+                                        let src_transform = if let Some(src_origin) = data.tracking_origins.iter().find(|x| x.name == last.src) {
+                                            src_origin.get_offset()?.into()
+                                        } else {
+                                            log::warn!("Source origin \"{}\" not found, applying calibration with identity source", last.src);
+                                            TransformD::default()
+                                        };
+
                                         for o in data.tracking_origins.iter() {
                                             if o.name != last.dst {
                                                 continue;
                                             }
 
-                                            let offset =
-                                                last.offset * TransformD::from(o.get_offset()?);
+                                            let offset = last.offset * src_transform;
                                             o.set_offset(offset.into())?;
                                             log::info!(
                                                 "Offset successfully applied to: {}",


### PR DESCRIPTION
The PR contains fixes for the following issues happening with non-continuous calibration:
* `motoc monitor` shows zeroes for tracking origin offsets
* Invoking `motoc continue` twice or more stacks the applied offset, effectively sending one of the tracking origins away.
* `motoc calibrate` saves pre-calibration tracking origin transform, which is typically identity

With these changes I can stick a `motoc continue` into my Envision plugin list and have it restore calibration successfully on launch. Subsequent calibrations are stored and restored correctly too.

Note that I haven't tested continuous calibration with these changes, but I believe I didn't touch the code path used in it.