### PR TITLE
Update Homebrew Tap URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Other distros, install via cargo:
 cargo install --git https://github.com/galister/motoc.git
 ```
 
-Or via Homebrew ([AtomicXR tap](https://codeberg.org/shiloh/homebrew-atomicxr)):
+Or via Homebrew ([AtomicXR tap](https://tangled.sh/@matrixfurry.com/homebrew-atomicxr)):
 ```bash
-brew tap shiloh/atomicxr https://codeberg.org/shiloh/homebrew-atomicxr.git
+brew tap matrixfurry.com/atomicxr https://tangled.sh/@matrixfurry.com/homebrew-atomicxr
 brew install motoc
 ```
 


### PR DESCRIPTION
The AtomicXR Homebrew tap was migrated to Tangled as part of the AtomicXR v1 release.

I am sorry for adding the tap to this README before it was stable. This version of the tap is stable, and the URL will not change again in the future.